### PR TITLE
docs: fix pytest plugin example and Hatch locking claim

### DIFF
--- a/notebooks/2.7 Creating Packages.ipynb
+++ b/notebooks/2.7 Creating Packages.ipynb
@@ -241,7 +241,7 @@
     "\n",
     "The \"Hatch\" tool is like PDM/Poetry, but is based on multiple environments. This allows it to be a \"true\" all-in-one tool by replacing nox/tox. It comes with a fantastic \"Hatchling\" backend that is currently the nicest PEP 517 builder; this is what I nearly always use.\n",
     "\n",
-    "Hatch doesn't support locking environments yet (was waiting on an official solution, but that's been hard to agree on). But Hatchling is currently the nicest and most extensible PEP 517 builder available! I'd highly recommend using it (even with PDM, which is what I usually do)."
+    "Hatch waited for an official lock file standard, and got one: since Hatch 1.17, `hatch env lock` writes a PEP 751 `pylock.toml` (with a uv or pip backend), and `hatch dep sync` installs from it. And Hatchling is currently the nicest and most extensible PEP 517 builder available! I'd highly recommend using it (even with PDM, which is what I usually do)."
    ]
   },
   {

--- a/notebooks/3.1 pytest.ipynb
+++ b/notebooks/3.1 pytest.ipynb
@@ -260,7 +260,7 @@
     "\n",
     "You can also use `xfail` for tests that are expected to fail (you can even strictly test them as failing if you want). You can use `parametrize` to make a single parameterized test instead of sharing them (with fixtures). There's a `filterwarnings` mark, too.\n",
     "\n",
-    "Many pytest plugins support new marks too, like `pytest-parametrize`. You can also use custom marks to enable/disable groups of tests, or to pass data into fixtures."
+    "Many pytest plugins add new marks too, like the `timeout` mark from `pytest-timeout` or the `asyncio` mark from `pytest-asyncio`. You can also use custom marks to enable/disable groups of tests, or to pass data into fixtures."
    ]
   },
   {


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Two stale/incorrect facts in the notebooks:

- `3.1 pytest.ipynb` cited `pytest-parametrize` as a plugin that adds marks. No such plugin exists. Replaced with the `timeout` mark from pytest-timeout and the `asyncio` mark from pytest-asyncio.
- `2.7 Creating Packages.ipynb` said Hatch cannot lock environments. Hatch 1.17 (2026-05-31) added `hatch env lock`, which writes a PEP 751 `pylock.toml` through a uv or pip locker, plus `hatch dep sync` to install from it.

Markdown cells only, so no new dependencies.